### PR TITLE
Fixed test cases that were incorrect.

### DIFF
--- a/simple_test/fixtures/ast/context_condition/math_on_record.sim
+++ b/simple_test/fixtures/ast/context_condition/math_on_record.sim
@@ -1,6 +1,6 @@
 PROGRAM mathOnRecord;
   VAR a, b : RECORD a : INTEGER;
-                    b : ARRAY 6 OF INTEGER END;
+                    b : ARRAY 6 OF INTEGER; END;
 BEGIN
     a := a + b
 END mathOnRecord.

--- a/simple_test/fixtures/ast/context_condition/math_on_whole_array.sim
+++ b/simple_test/fixtures/ast/context_condition/math_on_whole_array.sim
@@ -1,5 +1,5 @@
 PROGRAM mathOnRecord;
-  VAR a, b : ARRAY 42 OF INTEGER END;
+  VAR a, b : ARRAY 42 OF INTEGER;
 BEGIN
     a := a DIV b
 END mathOnRecord.


### PR DESCRIPTION
I saved context conditions for last and noticed these test cases were still passing anyway. They were being marked incorrect syntactically first.