### PR TITLE
Created test case for reading into a constant.

### DIFF
--- a/simple_test/fixtures/ast/context_condition/read_into_const.ast
+++ b/simple_test/fixtures/ast/context_condition/read_into_const.ast
@@ -1,0 +1,1 @@
+error: cannot read into a non-variable.

--- a/simple_test/fixtures/ast/context_condition/read_into_const.sim
+++ b/simple_test/fixtures/ast/context_condition/read_into_const.sim
@@ -1,0 +1,5 @@
+PROGRAM const;
+    CONST s = 5;
+BEGIN
+    read s
+END const.


### PR DESCRIPTION
Designator can return a non-variable in the case that selector is not called on the constant, and should throw an error in that case when "read" into. This is a test case for that.